### PR TITLE
openshift: Change health check path

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -101,13 +101,13 @@ objects:
             timeoutSeconds: 1
             initialDelaySeconds: 5
             httpGet:
-              path: /healthcheck
+              path: /
               port: 5000
           livenessProbe:
             timeoutSeconds: 1
             initialDelaySeconds: 30
             httpGet:
-              path: /healthcheck
+              path: /
               port: 5000
           volumeMounts:
           - mountPath: /etc/product-listings-manager


### PR DESCRIPTION
Now 404 is returned when accessing /healthcheck and it will casue
health check failed.