### PR TITLE
Fix tests

### DIFF
--- a/product_listings_manager/tests/test_products.py
+++ b/product_listings_manager/tests/test_products.py
@@ -92,9 +92,9 @@ class TestGetModuleProductListings(object):
 
     def test_getModuleProductListings(self):
         label = 'RHEL-8.0.0'
-        module = 'ruby-2.5-820181217154935.9edba152'
+        module = 'ruby-2.5-820190111110530.9edba152'
         result = getModuleProductListings(label, module)
         expected = {
-            'AppStream-8.0.0': ['x86_64']
+            'AppStream-8.0.0': ['aarch64', 'ppc64le', 's390x', 'x86_64']
         }
         assert result == expected

--- a/product_listings_manager/tests/test_rest_api_v1.py
+++ b/product_listings_manager/tests/test_rest_api_v1.py
@@ -94,4 +94,4 @@ class TestModuleProductListings(object):
         path = '/api/v1.0/module-product-listings/{0}/{1}'.format(self.product_label, self.nvr)
         r = client.get(path)
         assert r.status_code == 404
-        assert r.get_json() == {'message': error_message}
+        assert error_message in r.get_json().get('message', '')


### PR DESCRIPTION
Fixes module name for a "live" test (the old one is not available
anymore).

Fixes check for "NOT FOUND" error message; newer version of
flask_restful adds a hint to the message so it looks like following.

    You have requested this URI [/api/v1.0/...] but did you mean
    /api/v1.0/module-product-listings/<label>/<module_build_nvr> ?

Signed-off-by: Lukas Holecek <hluk@email.cz>