### PR TITLE
Add REST API endpoint to list product labels

### DIFF
--- a/product_listings_manager/products.py
+++ b/product_listings_manager/products.py
@@ -339,12 +339,25 @@ class Products(object):
         return [row[0] for row in rows]
     get_module_overrides = staticmethod(get_module_overrides)
 
+    @staticmethod
+    def get_product_labels(compose_dbh):
+        dbc = compose_dbh.cursor()
+        qry = 'SELECT DISTINCT label FROM products'
+        Products.execute_query(dbc, qry)
+        rows = dbc.fetchall()
+        return [{'label': row[0]} for row in rows]
+
 
 def getProductInfo(label):
     """
     Get a list of the versions and variants of a product with the given label.
     """
     return Products.get_product_info(Products.compose_get_dbh(), label)
+
+
+def getProductLabels():
+    compose_dbh = Products.compose_get_dbh()
+    return Products.get_product_labels(compose_dbh)
 
 
 def getProductListings(productLabel, buildInfo):

--- a/product_listings_manager/rest_api_v1.py
+++ b/product_listings_manager/rest_api_v1.py
@@ -16,6 +16,7 @@ class Index(Resource):
             'product_info_url': url_for('.productinfo',
                                         label=':label',
                                         _external=True),
+            'product_labels_url': url_for('.productlabels', _external=True),
             'product_listings_url': url_for('.productlistings',
                                             label=':label',
                                             build_info=':build_info',
@@ -44,6 +45,15 @@ class ProductInfo(Resource):
         return [versions, variants]
 
 
+class ProductLabels(Resource):
+    def get(self):
+        try:
+            return products.getProductLabels()
+        except Exception:
+            utils.log_remote_call_error('API call getProductLabels() failed')
+            raise
+
+
 class ProductListings(Resource):
     def get(self, label, build_info):
         try:
@@ -70,5 +80,6 @@ api = Api(blueprint)
 api.add_resource(Index, '/')
 api.add_resource(About, '/about')
 api.add_resource(ProductInfo, '/product-info/<label>')
+api.add_resource(ProductLabels, '/product-labels')
 api.add_resource(ProductListings, '/product-listings/<label>/<build_info>')
 api.add_resource(ModuleProductListings, '/module-product-listings/<label>/<module_build_nvr>')

--- a/product_listings_manager/tests/test_products.py
+++ b/product_listings_manager/tests/test_products.py
@@ -2,6 +2,7 @@ from product_listings_manager.products import Products
 from product_listings_manager.products import getProductInfo
 from product_listings_manager.products import getProductListings
 from product_listings_manager.products import getModuleProductListings
+from product_listings_manager.products import getProductLabels
 import pytest
 
 
@@ -98,3 +99,14 @@ class TestGetModuleProductListings(object):
             'AppStream-8.0.0': ['aarch64', 'ppc64le', 's390x', 'x86_64']
         }
         assert result == expected
+
+
+class TestProductLabels(object):
+
+    def test_getProductLabels(self):
+        result = getProductLabels()
+        assert len(result) > 1200
+        print(result)
+        assert {'label': 'RHEL-6'} in result
+        assert {'label': 'RHEL-6-Client'} in result
+        assert {'label': 'RHEL-6-Server'} in result

--- a/product_listings_manager/tests/test_rest_api_v1.py
+++ b/product_listings_manager/tests/test_rest_api_v1.py
@@ -20,6 +20,7 @@ class TestIndex(object):
             'module_product_listings_url': 'http://localhost/api/v1.0/module-product-listings/:label/:module_build_nvr',
             'product_info_url': 'http://localhost/api/v1.0/product-info/:label',
             'product_listings_url': 'http://localhost/api/v1.0/product-listings/:label/:build_info',
+            'product_labels_url': 'http://localhost/api/v1.0/product-labels',
         }
         assert r.status_code == 200
         assert r.get_json() == expected_json
@@ -95,3 +96,16 @@ class TestModuleProductListings(object):
         r = client.get(path)
         assert r.status_code == 404
         assert error_message in r.get_json().get('message', '')
+
+
+class TestLabels(object):
+    labels = [
+        {'label': 'RHEL-5'},
+        {'label': 'RHEL-6'}
+    ]
+
+    @patch('product_listings_manager.products.getProductLabels', return_value=labels)
+    def test_get_product_info(self, mock_get_product_info, client):
+        r = client.get('/api/v1.0/product-labels')
+        assert r.status_code == 200
+        assert r.get_json() == mock_get_product_info.return_value


### PR DESCRIPTION
Adds api/v1.0/product-labels REST API endpoint which lists sorted
product label names in following format.

    [
        {
            "name": "ABC"
        },
        ...
        {
            "name": "XYZ"
        }
    ]

Fixes #64

Signed-off-by: Lukas Holecek <hluk@email.cz>