### PR TITLE
Don't ignore spec file changes in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,4 @@ build/*
 dist/*
 doc/build/*
 /config.py
-/product-listings-manager.spec
 *.rpm


### PR DESCRIPTION
Previously ignored because it was generated from
product-listings-manager.spec.in file, which was later removed (see
commit "3d57df6 tito: Configure tito").

Signed-off-by: Lukas Holecek <hluk@email.cz>