### PR TITLE
Change tito tag format to make it shorter

### DIFF
--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -4,6 +4,7 @@ tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)
 tag_commit_message_format = Release %(name)s %(version)s
+tag_format = v{version}-{release}
 
 [version_template]
 destination_file = product_listings_manager/__init__.py


### PR DESCRIPTION
Need to tag previous release with v0.4-1 to avoid `tito tag` failed

    git tag v0.4-1 product-listings-manager-0.4-1