### PR TITLE
Install new version of gunicorn in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,16 @@ RUN yum install -y epel-release \
     && yum -y update \
     && yum -y install \
         git \
-        python-gunicorn \
+        python-pip \
         python-flask \
         python-psycopg2 \
         python-sqlalchemy \
         python2-flask-restful \
         python2-flask-sqlalchemy \
-        python2-koji
+        python2-koji \
+    && pip install \
+        gunicorn \
+        futures
 
 WORKDIR /var/www/product-listings-manager
 


### PR DESCRIPTION
New version supports running in multi thread mode[1] and it's easy
to specify args via environment variable GUNICORN_CMD_ARGS[2].

[1] https://docs.gunicorn.org/en/stable/design.html?highlight=gthread#how-many-threads
[2] http://docs.gunicorn.org/en/stable/settings.html#settings

JIRA: COMPOSE-3602