### PR TITLE
Use fedora 29 instead of rawhide for py37 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services: docker
 matrix:
   include:
     # https://hub.docker.com/_/fedora/
-    - env: CONTAINER_IMAGE=fedora:rawhide TOXENV=py37
+    - env: CONTAINER_IMAGE=fedora:29 TOXENV=py37
     - env: CONTAINER_IMAGE=fedora:28 TOXENV=py36
     # https://hub.docker.com/_/centos/
     - env: CONTAINER_IMAGE=centos:7 TOXENV=py27

--- a/.travis/Dockerfile.fedora:29
+++ b/.travis/Dockerfile.fedora:29
@@ -1,4 +1,4 @@
-FROM fedora:rawhide
+FROM fedora:29
 
 WORKDIR /build
 


### PR DESCRIPTION
The new version of rpm-devel in fedora:rawhide causes dependencies
installation failed.