### PR TITLE
Fix pytest.config deprecated issue

### DIFF
--- a/product_listings_manager/conftest.py
+++ b/product_listings_manager/conftest.py
@@ -1,6 +1,9 @@
 # Flask < 1.0 does not have get_json.
 from flask import Response
 import json
+import pytest
+
+
 if not hasattr(Response, 'get_json'):
     def get_json(self, force=False, silent=False, cache=True):
         """ Minimal implementation we can use this in the tests. """
@@ -9,5 +12,18 @@ if not hasattr(Response, 'get_json'):
 
 
 def pytest_addoption(parser):
-    parser.addoption('--live', action='store_true',
+    parser.addoption('--live', action='store_true', default=False,
                      help='query live composedb and koji servers')
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "live: mark test as requiring live composedb and koji servers")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--live"):
+        return
+    skip_live = pytest.mark.skip(reason="use --live argument to query production servers")
+    for item in items:
+        if "live" in item.keywords:
+            item.add_marker(skip_live)

--- a/product_listings_manager/tests/test_products.py
+++ b/product_listings_manager/tests/test_products.py
@@ -7,12 +7,6 @@ from product_listings_manager.products import getProductLabels
 import pytest
 
 
-pytestmark = pytest.mark.skipif(
-    not pytest.config.getoption('--live', default=False),
-    reason='use --live argument to query production servers'
-)
-
-
 @pytest.fixture(scope='module')
 def app():
     app = create_app()
@@ -20,6 +14,7 @@ def app():
         yield app
 
 
+@pytest.mark.live
 class TestProductLive(object):
 
     def test_score(self):
@@ -62,6 +57,7 @@ class TestProductLive(object):
         pass
 
 
+@pytest.mark.live
 class TestGetProductInfo(object):
 
     def test_simple(self, app):
@@ -70,6 +66,7 @@ class TestGetProductInfo(object):
         assert result == ('6.9', ['EXTRAS-6'])
 
 
+@pytest.mark.live
 class TestGetProductListings(object):
 
     def test_simple(self, app):
@@ -87,6 +84,7 @@ class TestGetProductListings(object):
         assert result == expected
 
 
+@pytest.mark.live
 class TestGetModuleProductListings(object):
 
     def test_getModuleProductListings(self, app):
@@ -99,6 +97,7 @@ class TestGetModuleProductListings(object):
         assert result == expected
 
 
+@pytest.mark.live
 class TestProductLabels(object):
 
     def test_getProductLabels(self, app):


### PR DESCRIPTION
https://docs.pytest.org/en/latest/deprecations.html#pytest-config-global
https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option