### PR TITLE
Fix building container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,28 @@
-FROM centos:8
+FROM registry.centos.org/centos:8
 LABEL \
     name="product-listings-manager" \
     vendor="product-listings-manager developers" \
     license="MIT" \
     build-date=""
 
-RUN yum -y update \
+RUN yum install -y epel-release \
     && yum -y install \
-        gcc \
-        git \
-        krb5-devel \
-        postgresql-devel \
-        python36 \
-        python36-devel \
-        redhat-rpm-config \
-        rpm-devel \
+        --setopt=install_weak_deps=false \
+        --setopt=tsflags=nodocs \
+        git-core \
+        python3 \
+        python3-flask \
+        python3-flask-sqlalchemy \
+        python3-gunicorn \
+        python3-koji \
+        python3-pip \
+        python3-sqlalchemy \
     && yum -y clean all \
-    && rm -rf /var/cache/dnf \
+    && rm -rf /var/cache/yum \
     && rm -rf /tmp/*
+
+RUN pip3 install \
+        flask-restful==0.3.8
 
 WORKDIR /var/www/product-listings-manager
 
@@ -25,11 +30,6 @@ WORKDIR /var/www/product-listings-manager
 COPY .git .git
 RUN git reset --hard HEAD \
     && git checkout HEAD
-
-RUN pip3 install --no-cache-dir \
-        -r requirements.txt \
-        gunicorn \
-        futures
 
 ARG cacert_url
 RUN if [ -n "$cacert_url" ]; then \
@@ -42,7 +42,7 @@ USER 1001
 EXPOSE 5000
 
 ENTRYPOINT [ \
-    "gunicorn", \
+    "/usr/bin/gunicorn-3", \
     "--bind=0.0.0.0:5000", \
     "--access-logfile=-", \
     "--enable-stdio-inheritance", \

--- a/product_listings_manager/models.py
+++ b/product_listings_manager/models.py
@@ -125,7 +125,7 @@ class MatchVersions(db.Model):
     product = db.Column(db.String(100), primary_key=True)
 
     def __repr__(self):
-        return "<MatchVersion %s %s>" % (self.id, self.name, self.product)
+        return "<MatchVersion %s %s %s>" % (self.id, self.name, self.product)
 
 
 class Modules(db.Model):


### PR DESCRIPTION
Tested with podman.

Avoids using base image from rate-limited dockerhub.

Gets as much packages as possible from official centos and epel
repositories.