### PR TITLE
GitHub Actions tox improvements

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -27,7 +27,7 @@ jobs:
           sudo apt-get -y update
           sudo apt-get -y install libkrb5-dev
           python -m pip install --upgrade pip
-          pip install tox tox-gh-actions
+          pip install tox
 
       - name: Test with tox
         run: tox -e py

--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -30,7 +30,9 @@ jobs:
           pip install tox
 
       - name: Test with tox
-        run: tox -e py
+        run: |
+          PY=py$(echo ${{ matrix.python-version }} | tr -d ".")
+          tox -e ${PY}
 
       - name: Run coveralls-python
         env:


### PR DESCRIPTION
Improve the `tox` invocation for GitHub Actions:

* Remove `tox-gh-actions` module. Tox interprets `-e py` to mean "run tests with the Python version that invoked `tox`". That means that tox will automatically choose the right version of Python for the tests, and we do not need the separate `tox-gh-actions` module.

* Run tox tests with `pyXX` environments. Instead of running tox with `tox -e py`, run with eg. `tox -e py36`. This matches more closely what a local user would do, and it allows us to filter dependencies in `tox.ini` according to Python versions.