### PR TITLE
Fix double slash in URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,6 @@ RUN yum -y install \
         python3-psycopg2 \
         python3-sqlalchemy
 
-RUN pip3 install \
-        flask-restful==0.3.8
-
 WORKDIR /var/www/product-listings-manager
 
 # Restore working tree from current git commit in container.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,17 @@
-FROM registry.centos.org/centos:8
+FROM registry.fedoraproject.org/fedora:36
 LABEL \
     name="product-listings-manager" \
     vendor="product-listings-manager developers" \
     license="MIT" \
     build-date=""
 
-# https://www.centos.org/centos-linux-eol/
-RUN sed -i -e "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-* \
-    && sed -i -e "s|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" /etc/yum.repos.d/CentOS-* \
-    && yum install -y epel-release \
-    && yum -y install \
+RUN yum -y install \
         --setopt=install_weak_deps=false \
         --setopt=tsflags=nodocs \
         git-core \
         python3 \
         python3-flask \
+        python3-flask-restful \
         python3-flask-sqlalchemy \
         python3-gunicorn \
         python3-koji \

--- a/tests/test_double_slash_url.py
+++ b/tests/test_double_slash_url.py
@@ -1,0 +1,6 @@
+class TestDoubleSlashURL(object):
+    def test_double_slash_url(self, client):
+        r = client.get("/api//v1.0/", follow_redirects=True)
+        assert r.status_code == 200
+        assert len(r.history) == 1
+        assert r.request.path == "/api/v1.0/"


### PR DESCRIPTION
Change base image to fedora to avoid 404 when getting double slash in URL.