### PR TITLE
Update dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -110,7 +110,7 @@ doc = ["sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
 
 [[package]]
 name = "faker"
-version = "16.7.0"
+version = "16.8.1"
 description = "Faker is a Python package that generates fake data for you."
 category = "main"
 optional = true
@@ -519,7 +519,7 @@ watchdog = ["watchdog"]
 
 [[package]]
 name = "zipp"
-version = "3.12.1"
+version = "3.13.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
@@ -705,8 +705,8 @@ exceptiongroup = [
 ]
 factory-boy = []
 faker = [
-    {file = "Faker-16.7.0-py3-none-any.whl", hash = "sha256:c522c78f2d7572724bde05de8571205e9a594f95b57e08e388e0677976ebd400"},
-    {file = "Faker-16.7.0.tar.gz", hash = "sha256:4b98c197169e083304afd12c1ee1e5101f5c817161c3d690eb318a15b805108d"},
+    {file = "Faker-16.8.1-py3-none-any.whl", hash = "sha256:64dcf95eee9f00d2547f29f6762aec80fc3ccbe3752bfa2c45082a6e2cc4d74a"},
+    {file = "Faker-16.8.1.tar.gz", hash = "sha256:ad181f6f9cdc0f7d70ea6eaea35ab4b6549391fbaaea7629cc567aeb2757d296"},
 ]
 flake8 = [
     {file = "flake8-6.0.0-py2.py3-none-any.whl", hash = "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7"},
@@ -956,6 +956,6 @@ urllib3 = [
 ]
 werkzeug = []
 zipp = [
-    {file = "zipp-3.12.1-py3-none-any.whl", hash = "sha256:6c4fe274b8f85ec73c37a8e4e3fa00df9fb9335da96fb789e3b96b318e5097b3"},
-    {file = "zipp-3.12.1.tar.gz", hash = "sha256:a3cac813d40993596b39ea9e93a18e8a2076d5c378b8bc88ec32ab264e04ad02"},
+    {file = "zipp-3.13.0-py3-none-any.whl", hash = "sha256:e8b2a36ea17df80ffe9e2c4fda3f693c3dad6df1697d3cd3af232db680950b0b"},
+    {file = "zipp-3.13.0.tar.gz", hash = "sha256:23f70e964bc11a34cef175bc90ba2914e1e4545ea1e3e2f67c079671883f9cb6"},
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-wheel==0.37.1
-pip==22.2.2
-setuptools==65.4.1
+wheel==0.38.4
+pip==23.0
+setuptools==67.2.0


### PR DESCRIPTION
Bump pip from 22.2.2 to 23.0

Bumps [pip](https://github.com/pypa/pip) from 22.2.2 to 23.0.
- [Release notes](https://github.com/pypa/pip/releases)
- [Changelog](https://github.com/pypa/pip/blob/main/NEWS.rst)
- [Commits](https://github.com/pypa/pip/compare/22.2.2...23.0)

---
updated-dependencies:
- dependency-name: pip dependency-type: direct:production update-type: version-update:semver-major ...

Bump setuptools from 65.4.1 to 67.2.0

Bumps [setuptools](https://github.com/pypa/setuptools) from 65.4.1 to 67.2.0.
- [Release notes](https://github.com/pypa/setuptools/releases)
- [Changelog](https://github.com/pypa/setuptools/blob/main/CHANGES.rst)
- [Commits](https://github.com/pypa/setuptools/compare/v65.4.1...v67.2.0)

---
updated-dependencies:
- dependency-name: setuptools dependency-type: direct:production update-type: version-update:semver-major ...

Bump wheel from 0.37.1 to 0.38.4

Bumps [wheel](https://github.com/pypa/wheel) from 0.37.1 to 0.38.4.
- [Release notes](https://github.com/pypa/wheel/releases)
- [Changelog](https://github.com/pypa/wheel/blob/main/docs/news.rst)
- [Commits](https://github.com/pypa/wheel/compare/0.37.1...0.38.4)

---
updated-dependencies:
- dependency-name: wheel dependency-type: direct:production update-type: version-update:semver-minor ...