### PR TITLE
Return named colums in dbquery API

### DIFF
--- a/product_listings_manager/db_queries.py
+++ b/product_listings_manager/db_queries.py
@@ -12,7 +12,7 @@ from product_listings_manager.schemas import SqlQuery
 logger = logging.getLogger(__name__)
 
 
-def execute_queries(db, queries: list[SqlQuery]) -> list[list[Any]]:
+def execute_queries(db, queries: list[SqlQuery]) -> list[dict[str, Any]]:
     with db.begin():
         for query in queries:
             query_text = query.query
@@ -29,6 +29,6 @@ def execute_queries(db, queries: list[SqlQuery]) -> list[list[Any]]:
         db.commit()
 
     try:
-        return [list(row) for row in result]
+        return [dict(row._mapping) for row in result]
     except ResourceClosedError:
         return []

--- a/product_listings_manager/rest_api_v1.py
+++ b/product_listings_manager/rest_api_v1.py
@@ -332,7 +332,7 @@ def dbquery(
     query_or_queries: SqlQuery | list[SqlQuery | str] | str,
     request: Request,
     db: Session = Depends(get_db),
-) -> list[list[Any]]:
+) -> list[dict[str, Any]]:
     """
     Executes given SQL queries with optionally provided parameters.
 

--- a/tests/test_dbquery.py
+++ b/tests/test_dbquery.py
@@ -89,8 +89,18 @@ class TestDBQuery:
         )
         assert r.status_code == 200, r.text
         assert r.json() == [
-            [p1.id, "product1", "1.2", "Client"],
-            [p2.id, "product2", "2.3", "Server"],
+            {
+                "id": p1.id,
+                "label": "product1",
+                "version": "1.2",
+                "variant": "Client",
+            },
+            {
+                "id": p2.id,
+                "label": "product2",
+                "version": "2.3",
+                "variant": "Server",
+            },
         ]
 
     def test_db_query_insert(self, auth_client):
@@ -119,7 +129,14 @@ class TestDBQuery:
             )
             assert r.status_code == 200, r.text
 
-        assert r.json() == [["product1", "1.2", "Client", 1]]
+        assert r.json() == [
+            {
+                "label": "product1",
+                "version": "1.2",
+                "variant": "Client",
+                "allow_source_only": 1,
+            }
+        ]
 
     def test_db_query_insert_with_select(self, auth_client):
         queries = [
@@ -143,7 +160,14 @@ class TestDBQuery:
             headers=auth_headers(),
         )
         assert r.status_code == 200, r.text
-        assert r.json() == [["product1", "1.2", "Client", 1]]
+        assert r.json() == [
+            {
+                "label": "product1",
+                "version": "1.2",
+                "variant": "Client",
+                "allow_source_only": 1,
+            }
+        ]
 
     def test_db_query_insert_with_rollback(self, auth_client):
         queries = [


### PR DESCRIPTION
Instead of simple array of arrays the API response would be a list of objects with column names:

    # Old response
    [["product1", "1.2", "Client", 1]]

    # New response
    [{"label": "product1", "version": "1.2", "variant": "Client", "allow_source_only": 1}]