### PR TITLE
Use Renovate bot instead of dependabot and update Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
-version: 2
-updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "monthly"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices",
+    ":enablePreCommit",
+    "group:all",
+    "workarounds:supportRedHatImageVersion",
+    ":gitSignOff",
+    "schedule:weekly"
+  ],
+  "packageRules": [
+    {
+      "description": "Patch and digest updates",
+      "matchUpdateTypes": [
+        "patch",
+        "digest"
+      ],
+      "groupName": "Auto merged updates",
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
+      "description": "pre-commit-renovate plugin",
+      "matchPackageNames": [
+        "maxbrunet/pre-commit-renovate"
+      ],
+      "groupName": "Auto merged updates",
+      "automerge": true,
+      "platformAutomerge": true
+    },
+  ],
+  "vulnerabilityAlerts": {
+    "vulnerabilityFixStrategy": "highest"
+  },
+  "configMigration": true
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-wheel==0.44.0
-pip==24.2
-setuptools==75.1.0


### PR DESCRIPTION
User redhat-renovate-bot (invited to the repo with Write access) should update all dependencies in batch every Monday (create a PR and after CI succeeds, auto-merge the change).

JIRA: RHELWF-11847