### PR TITLE
Disable Renovate's Dependency Dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,8 @@
     "config:best-practices",
     ":enablePreCommit",
     "group:all",
-    "workarounds:supportRedHatImageVersion",
     ":gitSignOff",
+    ":disableDependencyDashboard",
     "schedule:weekly"
   ],
   "packageRules": [


### PR DESCRIPTION
Also, removes unneeded workaround for image versions.